### PR TITLE
chore: plucky reached end-of-life

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The supported releases of Ubuntu for different CPU architecture.
 | `ci-ubuntu` | `mantic-amd64`     | `mantic-arm64`     | ✔           |
 | `ci-ubuntu` | `noble-amd64`      | `noble-arm64`      | -           |
 | `ci-ubuntu` | `oracular-amd64`   | `oracular-arm64`   | ✔           |
-| `ci-ubuntu` | `plucky-amd64`     | `plucky-arm64`     | -           |
+| `ci-ubuntu` | `plucky-amd64`     | `plucky-arm64`     | ✔           |
 | `ci-ubuntu` | `questing-amd64`   | `questing-arm64`   | -           |
 | `ci-ubuntu` | `resolute-amd64`   | `resolute-arm64`   | -           |
 


### PR DESCRIPTION
Mark Ubuntu Plucky as end-of-life.